### PR TITLE
修复bug：当self::$lastClearTimePerProduct[$key]不存在时会报错

### DIFF
--- a/aliyun-php-sdk-core/Regions/LocationService.php
+++ b/aliyun-php-sdk-core/Regions/LocationService.php
@@ -78,7 +78,7 @@ class LocationService
 
 	private function checkCacheIsExpire($key)
     {
-        $lastClearTime = self::$lastClearTimePerProduct[$key];
+        $lastClearTime = isset(self::$lastClearTimePerProduct[$key]) ? self::$lastClearTimePerProduct[$key] : null;
         if ($lastClearTime == null)
         {
             $lastClearTime = time();


### PR DESCRIPTION
复现场景：
同时两次请求1个资源的播放url时就会报错；